### PR TITLE
Fixed native-maven-plugin for OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-/.settings
-/.project
-/.classpath
+*.settings
+*.project
+*.classpath
+*.idea
+*.iml
 /target/classes
 /target/maven-archiver
 /target/native

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ mp3.close();
 
 Compilation
 -----------
-on Debian Wheezy (libshout 2.2) and Jessie (libshout 2.3)
+#### on Debian Wheezy (libshout 2.2) and Jessie (libshout 2.3)
  
 ``` bash
 apt-get install git libshout3-dev gcc openjdk-7-jdk maven
@@ -50,7 +50,7 @@ cd libshout-java
 mvn install
 ```
 
-on CentOS 6.6, 7.1, 7.2
+#### on CentOS 6.6, 7.1, 7.2
  
 ``` bash
 yum install git libshout-devel gcc java-1.7.0-openjdk-devel
@@ -70,6 +70,28 @@ cd libshout-java
 /usr/local/maven/bin/mvn install
 ```
 
-on Ubuntu, Windows, OpenSuse etc
+#### on Mac OS X 10.12.1
+``` bash
+
+### Prereqs
+# Install Homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# Install Caskroom
+brew tap caskroom/cask
+# Install XCode CLI Tools (or XCode from the App Store)
+xcode-select --install
+# Install Java (found Caskroom to be the most reliable method)
+brew cask install java
+# Install Maven
+brew install maven
+
+### Build libshout-java
+git clone https://github.com/OlegKunitsyn/libshout-java.git
+cd libshout-java
+maven install
+
+```
+
+#### on Ubuntu, Windows, OpenSuse etc
  
 please commit your story

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
 								<fileName>libshout.c</fileName>
 							</fileNames>
 						</source>
+						<source>
+							<directory>${java.home}/../include/darwin</directory>
+						</source>
 					</sources>
 					<compilerProvider>generic-classic</compilerProvider>
 					<compilerExecutable>gcc</compilerExecutable>

--- a/src/test/java/com/gmail/kunicins/olegs/libshout/LibshoutTest.java
+++ b/src/test/java/com/gmail/kunicins/olegs/libshout/LibshoutTest.java
@@ -22,7 +22,9 @@ public class LibshoutTest {
 	
 	@Test
 	public void testVersion() {
-		assertEquals("2.2.2", this.libshout.getVersion());
+		String currentVersion = this.libshout.getVersion();
+		assertTrue("Expected Libshout version 2.2.2 or greater, but found version " + currentVersion,
+				"2.2.2".compareTo(currentVersion) <= 0);
 	}
 	
 	@Test


### PR DESCRIPTION
Needed an extra source folder on OS X for `jni_md.h` + revised test and documentation
