### PR TITLE
Custom shared library file location support

### DIFF
--- a/src/main/java/com/gmail/kunicins/olegs/libshout/Libshout.java
+++ b/src/main/java/com/gmail/kunicins/olegs/libshout/Libshout.java
@@ -42,6 +42,9 @@ public class Libshout implements AutoCloseable {
 	 *     instance = shout_new();
 	 *   </code>
 	 * </p>
+	 * <p>
+	 *   If the library has already been loaded (by a previous call to a constructor, it will <b>not</b> be reloaded.
+	 * </p>
 	 *
 	 * @param libraryPath The path of the libshout java shared library file, or null to use the default paths.
 	 * @throws IOException If an error occurs while initializing the library.


### PR DESCRIPTION
This adds another constructor to the Libshout library, to specify custom paths for the location of the shared library file.