### PR TITLE
(Git)ignore target/ files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,19 @@
+# eclipse files
 *.settings
 *.project
 *.classpath
-*.idea
+
+# intellij files
+.idea
 *.iml
-/target/classes
-/target/maven-archiver
-/target/native
-/target/objs
-/target/surefire
-/target/surefire-reports
-/target/test-classes
+
+# virtual machine crash logs
+hs_err_pid*
+
+# maven files
+target/
+
+# include releases
+!target/libshout-java.so
+!target/libshout-java.64.so
+!target/libshout-java-*.jar


### PR DESCRIPTION
The updated .gitignore file will ignore all new ```target/``` files by default, except the specific shared library files and the JAR release. As before, except you do not need to add all new target/ folders manually.