### PR TITLE
exceptions no longer used for flow control

### DIFF
--- a/src/main/java/com/gmail/kunicins/olegs/libshout/Libshout.java
+++ b/src/main/java/com/gmail/kunicins/olegs/libshout/Libshout.java
@@ -1,14 +1,31 @@
 package com.gmail.kunicins.olegs.libshout;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 public class Libshout implements AutoCloseable {
+
+	private static final String[] LIBSHOUT_SEARCH_PATHS = {
+			System.getProperty("user.dir") + "/libshout-java.so",
+			System.getProperty("user.dir") + "/target/libshout-java.so"};
+
 	static {
-		try {
-			System.load(System.getProperty("user.dir") + "/libshout-java.so");
-		} catch (UnsatisfiedLinkError e) {
-			System.load(System.getProperty("user.dir") + "/target/libshout-java.so");
+
+		boolean libshoutFound = false;
+		for (String sharedObjectLocation : LIBSHOUT_SEARCH_PATHS) {
+			File libshoutSo = new File(sharedObjectLocation);
+			if (libshoutSo.exists()) {
+				libshoutFound = true;
+				System.load(sharedObjectLocation);
+				break;
+			}
 		}
+		if (!libshoutFound) {
+			throw new UnsatisfiedLinkError("Could not find path to Libshout shared object in possible paths: "
+					+ Arrays.toString(LIBSHOUT_SEARCH_PATHS));
+		}
+
 	}
 	private static final int SUCCESS = 0;
 	private static final int CONNECTED = -7;


### PR DESCRIPTION
* File paths are first checked before calling `System.load`
* The first path that is found is attempted (just like a normal `$PATH` variable)
* Any stack trace is propagated directly

Should take care of #19 